### PR TITLE
feat: add new chat button outside sidebar and move dark mode toggle

### DIFF
--- a/frontend/src/components/custom/header.tsx
+++ b/frontend/src/components/custom/header.tsx
@@ -3,14 +3,19 @@ import React from "react";
 
 interface HeaderProps {
   children?: React.ReactNode;
+  rightSection?: React.ReactNode;
 }
 
-export const Header = ({ children }: HeaderProps) => {
+export const Header = ({ children, rightSection }: HeaderProps) => {
   return (
     <>
       <header className="flex items-center justify-between px-2 sm:px-4 py-2 bg-background text-black dark:text-white w-full">
         <div className="flex items-center space-x-1 sm:space-x-2">
           {children}
+        </div>
+        
+        <div className="flex items-center space-x-2">
+          {rightSection}
           <ThemeToggle />
         </div>
       </header>

--- a/frontend/src/components/custom/message.tsx
+++ b/frontend/src/components/custom/message.tsx
@@ -88,32 +88,41 @@ export const ThinkingMessage = () => {
       data-role={role}
     >
       <div className="flex gap-4 w-full rounded-xl items-center py-3">
-        <motion.div
-          className="size-8 flex items-center rounded-full justify-center ring-1 shrink-0 ring-border bg-background"
-          animate={{
-            boxShadow: [
-              "0 0 0 rgba(120, 120, 255, 0)",
-              "0 0 8px rgba(120, 120, 255, 0.5)",
-              "0 0 0 rgba(120, 120, 255, 0)",
-            ],
-          }}
-          transition={{
-            duration: 2,
-            repeat: Infinity,
-            ease: "easeInOut",
-          }}
-        >
-          <motion.div
-            animate={{ rotate: 360 }}
-            transition={{
-              duration: 2,
-              repeat: Infinity,
-              ease: "linear",
+        <div className="size-8 flex items-center justify-center relative">
+          {/* Outer pulsing circle */}
+          <motion.div 
+            className="absolute inset-0 rounded-full bg-primary/5 dark:bg-primary/10"
+            animate={{
+              scale: [0.9, 1.05, 0.9],
+              opacity: [0.5, 0.8, 0.5],
+              boxShadow: [
+                '0 0 0 rgba(120, 120, 255, 0)',
+                '0 0 10px rgba(120, 120, 255, 0.4)',
+                '0 0 0 rgba(120, 120, 255, 0)'
+              ]
             }}
-          >
-            <SparklesIcon size={14} />
-          </motion.div>
-        </motion.div>
+            transition={{
+              duration: 2.5,
+              repeat: Infinity,
+              ease: "easeInOut",
+              times: [0, 0.5, 1]
+            }}
+          />
+          
+          {/* Static border circle */}
+          <div className="size-8 flex items-center rounded-full justify-center ring-1 shrink-0 ring-border bg-background z-10">
+            <motion.div
+              animate={{ rotate: 360 }}
+              transition={{
+                duration: 2,
+                repeat: Infinity,
+                ease: "linear",
+              }}
+            >
+              <SparklesIcon size={14} />
+            </motion.div>
+          </div>
+        </div>
         <div className="flex items-center py-3">
           <LoadingDots />
         </div>

--- a/frontend/src/components/custom/sidebar.tsx
+++ b/frontend/src/components/custom/sidebar.tsx
@@ -45,14 +45,15 @@ export function Sidebar({
       <div className="flex flex-col h-full p-4">
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-lg font-semibold">Chats</h2>
-          <Button variant="ghost" size="icon" onClick={onClose}>
+          <Button variant="ghost" size="icon" className="size-9 rounded-full" onClick={onClose}>
             <X className="h-4 w-4" />
           </Button>
         </div>
         <Button
           onClick={onNewChat}
           className="mb-4 flex items-center gap-2"
-          variant="outline"
+          variant="ghost"
+          size="sm"
         >
           <PlusCircle className="h-4 w-4" />
           New Chat

--- a/frontend/src/components/custom/theme-toggle.tsx
+++ b/frontend/src/components/custom/theme-toggle.tsx
@@ -7,14 +7,15 @@ export function ThemeToggle() {
 
   return (
     <Button
-      variant="outline"
-      className="bg-background border border-gray text-gray-600 hover:white dark:text-gray-200 h-10"
+      variant="ghost"
+      size="icon"
+      className="size-9 rounded-full"
       onClick={toggleTheme}
     >
       {isDarkMode ? (
-        <Moon className="h-[1.2rem] w-[1.2rem]" />
+        <Moon className="h-4 w-4" />
       ) : (
-        <Sun className="h-[1.2rem] w-[1.2rem]" />
+        <Sun className="h-4 w-4" />
       )}
       <span className="sr-only">Toggle theme</span>
     </Button>

--- a/frontend/src/pages/chat/chat.tsx
+++ b/frontend/src/pages/chat/chat.tsx
@@ -10,7 +10,7 @@ import { Overview } from "@/components/custom/overview";
 import { Header } from "@/components/custom/header";
 import { Sidebar } from "@/components/custom/sidebar";
 import { Button } from "@/components/ui/button";
-import { Menu } from "lucide-react";
+import { Menu, PlusCircle } from "lucide-react";
 import { v4 as uuidv4 } from "uuid";
 import { sendChatMessage } from "@/services/api";
 
@@ -245,18 +245,28 @@ export function Chat() {
   return (
     <div className="flex flex-col min-w-0 h-dvh bg-background">
       <Header>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="mr-2"
-          onClick={() => setIsSidebarOpen(!isSidebarOpen)}
-        >
-          <Menu className="h-5 w-5" />
-        </Button>
+        <div className="flex items-center space-x-2">
+          <Button 
+            variant="ghost" 
+            size="icon"
+            onClick={() => setIsSidebarOpen(!isSidebarOpen)}
+            className="size-9 rounded-full"
+          >
+            <Menu className="h-4 w-4" />
+          </Button>
+          <Button
+            onClick={createNewChat}
+            variant="ghost"
+            size="icon"
+            className="size-9 rounded-full"
+          >
+            <PlusCircle className="h-4 w-4" />
+          </Button>
+        </div>
       </Header>
 
-      <Sidebar
-        isOpen={isSidebarOpen}
+      <Sidebar 
+        isOpen={isSidebarOpen} 
         onClose={() => setIsSidebarOpen(false)}
         onDeleteChat={handleDeleteChat}
         chats={getDisplayChats()}
@@ -264,7 +274,7 @@ export function Chat() {
         onSelectChat={selectChat}
         onNewChat={createNewChat}
       />
-
+      
       <div
         className="flex flex-col min-w-0 gap-6 flex-1 overflow-y-scroll pt-4"
         ref={messagesContainerRef}


### PR DESCRIPTION
- Moved the dark mode toggle to the top right of the screen for better accessibility.
- Added a "New Chat" button to the top left of the header, allowing users to create new chats without opening the sidebar.
- Updated the styling of the "New Chat" button in the sidebar to be consistent with other buttons.
- Enhanced the loading spinner with a smoother pulse effect for the circle around the sparkles.